### PR TITLE
Add ResumableUpload.invalid().

### DIFF
--- a/gooresmed/upload.py
+++ b/gooresmed/upload.py
@@ -246,6 +246,16 @@ class ResumableUpload(_UploadBase):
         self._bytes_uploaded = 0
         self._total_bytes = None
         self._upload_url_with_id = None
+        self._invalid = False
+
+    @property
+    def invalid(self):
+        """bool: Indicates if the upload is in an invalid state.
+
+        This will occur if a call to :meth:`transmit_next_chunk` fails.
+        To recover from such a failure, call :meth:`recover`.
+        """
+        return self._invalid
 
     @property
     def chunk_size(self):
@@ -365,6 +375,7 @@ class ResumableUpload(_UploadBase):
 
         Raises:
             ValueError: If the current upload has finished.
+            ValueError: If the current upload is in an invalid state.
             ValueError: If the current upload has not been initiated.
             ValueError: If the location in the stream (i.e. ``stream.tell()``)
                 does not agree with ``bytes_uploaded``.
@@ -373,6 +384,9 @@ class ResumableUpload(_UploadBase):
         """
         if self.finished:
             raise ValueError(u'Upload has finished.')
+        if self.invalid:
+            raise ValueError(
+                u'Upload is in an invalid state. To recover call `recover()`.')
         if self.upload_url_with_id is None:
             raise ValueError(
                 u'This upload has not been initiated. Please call '
@@ -417,14 +431,21 @@ class ResumableUpload(_UploadBase):
             # Tombstone the current upload so it cannot be used again.
             self._finished = True
         elif status_code == PERMANENT_REDIRECT:
-            bytes_range = _helpers.header_required(response, u'range')
+            try:
+                bytes_range = _helpers.header_required(response, u'range')
+            except exceptions.InvalidResponse:
+                self._invalid = True
+                raise
+
             match = _BYTES_RANGE_RE.match(bytes_range)
             if match is None:
+                self._invalid = True
                 raise exceptions.InvalidResponse(
                     response, u'Unexpected "range" header', bytes_range,
                     u'Expected to be of the form "bytes=0-{end}"')
             self._bytes_uploaded = int(match.group(u'end_byte')) + 1
         else:
+            self._invalid = True
             raise exceptions.InvalidResponse(
                 response, u'Response has unexpected status code', status_code,
                 u'Expected either "200 OK" or "308 Permanent Redirect"')
@@ -492,6 +513,30 @@ class ResumableUpload(_UploadBase):
             self.upload_url_with_id, data=payload, headers=headers)
         self._process_response(result)
         return result
+
+    def recover(self, transport):
+        """Recover from a failure.
+
+        This method should be used when a :class:`ResumableUpload` is in an
+        :attr:`~ResumableUpload.invalid` state due to a request failure.
+
+        This will verify the progress with the server and make sure the
+        current upload is in a valid state before :meth:`transmit_next_chunk`
+        can be used again.
+
+        Args:
+            transport (object): An object which can make authenticated
+                requests via a ``put()`` method which accepts an
+                upload URL, a ``data`` keyword argument and a
+                ``headers`` keyword argument.
+
+        Returns:
+            object: The return value of ``transport.put()``.
+
+        Raises:
+            NotImplementedError: Always.
+        """
+        raise NotImplementedError
 
 
 def _get_boundary():

--- a/tests/system/test_upload.py
+++ b/tests/system/test_upload.py
@@ -269,4 +269,5 @@ def test_resumable_upload_bad_chunk_size(authorized_transport, stream):
     # URL is unusable.
     upload._chunk_size = upload_mod.UPLOAD_CHUNK_SIZE
     stream.seek(0)
+    upload._invalid = False
     check_bad_chunk(upload, authorized_transport)

--- a/tests/unit/test_upload.py
+++ b/tests/unit/test_upload.py
@@ -183,6 +183,19 @@ class TestResumableUpload(object):
         with pytest.raises(ValueError):
             upload_mod.ResumableUpload(RESUMABLE_URL, 1)
 
+    def test_invalid_property(self):
+        upload = upload_mod.ResumableUpload(RESUMABLE_URL, ONE_MB)
+        # Default value of @property.
+        assert not upload.invalid
+
+        # Make sure we cannot set it on public @property.
+        with pytest.raises(AttributeError):
+            upload.invalid = False
+
+        # Set it privately and then check the @property.
+        upload._invalid = True
+        assert upload.invalid
+
     def test_chunk_size_property(self):
         upload = upload_mod.ResumableUpload(RESUMABLE_URL, ONE_MB)
         # Default value of @property.
@@ -340,8 +353,20 @@ class TestResumableUpload(object):
     def test__prepare_request_already_finished(self):
         upload = upload_mod.ResumableUpload(RESUMABLE_URL, ONE_MB)
         upload._finished = True
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError) as exc_info:
             upload._prepare_request()
+
+        assert exc_info.value.args == (u'Upload has finished.',)
+
+    def test__prepare_request_invalid(self):
+        upload = upload_mod.ResumableUpload(RESUMABLE_URL, ONE_MB)
+        assert not upload.finished
+        upload._invalid = True
+        with pytest.raises(ValueError) as exc_info:
+            upload._prepare_request()
+
+        assert exc_info.match(u'invalid state')
+        assert exc_info.match(u'recover()')
 
     def test__prepare_request_not_initiated(self):
         upload = upload_mod.ResumableUpload(RESUMABLE_URL, ONE_MB)
@@ -390,6 +415,8 @@ class TestResumableUpload(object):
 
     def test__process_response_bad_status(self):
         upload = upload_mod.ResumableUpload(RESUMABLE_URL, ONE_MB)
+        # Make sure the upload is valid before the failure.
+        assert not upload.invalid
         response = self._mock_response(http_client.NOT_FOUND, {})
         with pytest.raises(exceptions.InvalidResponse) as exc_info:
             upload._process_response(response)
@@ -398,6 +425,8 @@ class TestResumableUpload(object):
         assert error.response is response
         assert len(error.args) == 3
         assert error.args[1] == response.status_code
+        # Make sure the upload is invalid after the failure.
+        assert upload.invalid
 
     def test__process_response_success(self):
         upload = upload_mod.ResumableUpload(RESUMABLE_URL, ONE_MB)
@@ -415,8 +444,12 @@ class TestResumableUpload(object):
     def test__process_response_partial_no_range(self):
         upload = upload_mod.ResumableUpload(RESUMABLE_URL, ONE_MB)
         response = self._mock_response(upload_mod.PERMANENT_REDIRECT, {})
+        # Make sure the upload is valid before the failure.
+        assert not upload.invalid
         with pytest.raises(exceptions.InvalidResponse) as exc_info:
             upload._process_response(response)
+        # Make sure the upload is invalid after the failure.
+        assert upload.invalid
 
         # Check the error response.
         error = exc_info.value
@@ -426,6 +459,8 @@ class TestResumableUpload(object):
 
     def test__process_response_partial_bad_range(self):
         upload = upload_mod.ResumableUpload(RESUMABLE_URL, ONE_MB)
+        # Make sure the upload is valid before the failure.
+        assert not upload.invalid
         headers = {u'range': u'nights 1-81'}
         response = self._mock_response(upload_mod.PERMANENT_REDIRECT, headers)
         with pytest.raises(exceptions.InvalidResponse) as exc_info:
@@ -436,6 +471,8 @@ class TestResumableUpload(object):
         assert error.response is response
         assert len(error.args) == 3
         assert error.args[1] == headers[u'range']
+        # Make sure the upload is invalid after the failure.
+        assert upload.invalid
 
     def test__process_response_partial(self):
         upload = upload_mod.ResumableUpload(RESUMABLE_URL, ONE_MB)
@@ -486,6 +523,11 @@ class TestResumableUpload(object):
         }
         transport.put.assert_called_once_with(
             upload.upload_url_with_id, data=payload, headers=expected_headers)
+
+    def test_recover(self):
+        upload = upload_mod.ResumableUpload(RESUMABLE_URL, ONE_MB)
+        with pytest.raises(NotImplementedError):
+            upload.recover(None)
 
 
 @mock.patch(u'random.randrange', return_value=1234567890123456789)


### PR DESCRIPTION
This way an instance can be marked when an unexpected response occurs.