### PR TITLE
Adding retries for **ANY** http request.

### DIFF
--- a/tests/unit/test__helpers.py
+++ b/tests/unit/test__helpers.py
@@ -93,15 +93,116 @@ class Test_require_status_code(object):
         assert error.args[3:] == status_codes
 
 
-def test_http_request():
-    transport = mock.Mock(spec=[u'request'])
-    method = u'POST'
-    url = u'http://test.invalid'
-    data = mock.sentinel.data
-    headers = {u'one': u'fish', u'blue': u'fish'}
-    ret_val = _helpers.http_request(
-        transport, method, url, data=data, headers=headers)
+class Test_calculate_retry_wait(object):
 
-    assert ret_val is transport.request.return_value
-    transport.request.assert_called_once_with(
-        method, url, data=data, headers=headers)
+    @mock.patch('random.randint', return_value=125)
+    def test_past_limit(self, randint_mock):
+        wait_time = _helpers.calculate_retry_wait(7)
+
+        assert wait_time == 64.125
+        randint_mock.assert_called_once_with(0, 1000)
+
+    @mock.patch('random.randint', return_value=250)
+    def test_at_limit(self, randint_mock):
+        wait_time = _helpers.calculate_retry_wait(6)
+
+        assert wait_time == 64.25
+        randint_mock.assert_called_once_with(0, 1000)
+
+    @mock.patch('random.randint', return_value=875)
+    def test_under_limit(self, randint_mock):
+        wait_time = _helpers.calculate_retry_wait(4)
+
+        assert wait_time == 16.875
+        randint_mock.assert_called_once_with(0, 1000)
+
+
+class Test_http_request(object):
+
+    @staticmethod
+    def _make_transport(*status_codes):
+        transport = mock.Mock(spec=[u'request'])
+        responses = [
+            mock.Mock(status_code=status_code, spec=[u'status_code'])
+            for status_code in status_codes]
+        transport.request.side_effect = responses
+        return transport, responses
+
+    def test_success_no_retry(self):
+        transport, responses = self._make_transport(http_client.OK)
+        method = u'POST'
+        url = u'http://test.invalid'
+        data = mock.sentinel.data
+        headers = {u'one': u'fish', u'blue': u'fish'}
+        ret_val = _helpers.http_request(
+            transport, method, url, data=data, headers=headers)
+
+        assert ret_val is responses[0]
+        transport.request.assert_called_once_with(
+            method, url, data=data, headers=headers)
+
+    @mock.patch('time.sleep')
+    @mock.patch('random.randint')
+    def test_success_with_retry(self, randint_mock, sleep_mock):
+        randint_mock.side_effect = [125, 625, 375]
+        transport, responses = self._make_transport(
+            http_client.SERVICE_UNAVAILABLE, _helpers.TOO_MANY_REQUESTS,
+            http_client.SERVICE_UNAVAILABLE, http_client.OK)
+        method = u'POST'
+        url = u'http://test.invalid'
+        data = mock.sentinel.data
+        headers = {u'one': u'fish', u'blue': u'fish'}
+        ret_val = _helpers.http_request(
+            transport, method, url, data=data, headers=headers)
+
+        assert ret_val is responses[3]
+
+        assert transport.request.call_count == 4
+        call = mock.call(method, url, data=data, headers=headers)
+        assert transport.request.mock_calls == [call, call, call, call]
+
+        assert randint_mock.call_count == 3
+        call = mock.call(0, 1000)
+        assert randint_mock.mock_calls == [call, call, call]
+
+        assert sleep_mock.call_count == 3
+        sleep_mock.assert_any_call(1.125)
+        sleep_mock.assert_any_call(2.625)
+        sleep_mock.assert_any_call(4.375)
+
+    @mock.patch('time.sleep')
+    @mock.patch('random.randint')
+    @mock.patch('google.resumable_media._helpers.MAX_CUMULATIVE_RETRY',
+                new=100)
+    def test_retry_exceeds_max_cumulative(self, randint_mock, sleep_mock):
+        randint_mock.side_effect = [875, 0, 375, 500, 500, 250, 125]
+        transport, responses = self._make_transport(
+            _helpers.TOO_MANY_REQUESTS, http_client.INTERNAL_SERVER_ERROR,
+            http_client.BAD_GATEWAY, http_client.SERVICE_UNAVAILABLE,
+            http_client.GATEWAY_TIMEOUT, _helpers.TOO_MANY_REQUESTS,
+            http_client.INTERNAL_SERVER_ERROR, http_client.BAD_GATEWAY)
+        method = u'PUT'
+        url = u'http://test.invalid'
+        data = mock.sentinel.data
+        headers = {u'ok': u'go'}
+        ret_val = _helpers.http_request(
+            transport, method, url, data=data, headers=headers)
+
+        assert ret_val is responses[7]
+
+        assert transport.request.call_count == 8
+        call = mock.call(method, url, data=data, headers=headers)
+        assert transport.request.mock_calls == [call] * 8
+
+        assert randint_mock.call_count == 7
+        call = mock.call(0, 1000)
+        assert randint_mock.mock_calls == [call] * 7
+
+        assert sleep_mock.call_count == 7
+        sleep_mock.assert_any_call(1.875)
+        sleep_mock.assert_any_call(2.0)
+        sleep_mock.assert_any_call(4.375)
+        sleep_mock.assert_any_call(8.5)
+        sleep_mock.assert_any_call(16.5)
+        sleep_mock.assert_any_call(32.25)
+        sleep_mock.assert_any_call(64.125)

--- a/tests/unit/test__helpers.py
+++ b/tests/unit/test__helpers.py
@@ -54,8 +54,8 @@ class Test_header_required(object):
 
 
 def test_get_status_code():
-    status_code = 200
-    response = mock.Mock(status_code=status_code, spec=[u'status_code'])
+    status_code = int(http_client.OK)
+    response = _make_response(status_code)
     assert status_code == _helpers.get_status_code(response)
 
 
@@ -76,13 +76,13 @@ class Test_require_status_code(object):
             int(http_client.CREATED),
         )
         for value in acceptable:
-            response = mock.Mock(status_code=value, spec=[u'status_code'])
+            response = _make_response(value)
             status_code = _helpers.require_status_code(response, status_codes)
             assert value == status_code
 
     def test_failure(self):
         status_codes = (http_client.CREATED, http_client.NO_CONTENT)
-        response = mock.Mock(status_code=http_client.OK, spec=[u'status_code'])
+        response = _make_response(http_client.OK)
         with pytest.raises(exceptions.InvalidResponse) as exc_info:
             _helpers.require_status_code(response, status_codes)
 
@@ -117,14 +117,98 @@ class Test_calculate_retry_wait(object):
         randint_mock.assert_called_once_with(0, 1000)
 
 
+class Test_wait_and_retry(object):
+
+    def test_success_no_retry(self):
+        truthy = 99
+        func = mock.Mock(return_value=truthy)
+        cutoff = 85.0
+        ret_val = _helpers.wait_and_retry(func, cutoff.__lt__)
+
+        assert ret_val is truthy
+        func.assert_called_once_with()
+
+    @mock.patch('time.sleep')
+    @mock.patch('random.randint')
+    def test_success_with_retry(self, randint_mock, sleep_mock):
+        randint_mock.side_effect = [125, 625, 375]
+        func = mock.Mock(side_effect=[883, 884, 885, 886])
+        cutoff = 885.0
+        predicate = cutoff.__lt__
+        ret_val = _helpers.wait_and_retry(func, predicate)
+
+        assert ret_val == 886
+        assert predicate(ret_val)
+
+        assert func.call_count == 4
+        assert func.mock_calls == [mock.call()] * 4
+
+        assert randint_mock.call_count == 3
+        assert randint_mock.mock_calls == [mock.call(0, 1000)] * 3
+
+        assert sleep_mock.call_count == 3
+        sleep_mock.assert_any_call(1.125)
+        sleep_mock.assert_any_call(2.625)
+        sleep_mock.assert_any_call(4.375)
+
+    @mock.patch('time.sleep')
+    @mock.patch('random.randint')
+    @mock.patch('google.resumable_media._helpers.MAX_CUMULATIVE_RETRY',
+                new=100.0)
+    def test_retry_exceeds_max_cumulative(self, randint_mock, sleep_mock):
+        randint_mock.side_effect = [875, 0, 375, 500, 500, 250, 125]
+        func = mock.Mock(side_effect=[64, 49, 36, 25, 16, 9, 4, 1])
+        cutoff = 0.0
+        predicate = cutoff.__gt__
+        ret_val = _helpers.wait_and_retry(func, predicate)
+
+        assert ret_val is 1
+        assert not predicate(ret_val)
+
+        assert func.call_count == 8
+        assert func.mock_calls == [mock.call()] * 8
+
+        assert randint_mock.call_count == 7
+        assert randint_mock.mock_calls == [mock.call(0, 1000)] * 7
+
+        assert sleep_mock.call_count == 7
+        sleep_mock.assert_any_call(1.875)
+        sleep_mock.assert_any_call(2.0)
+        sleep_mock.assert_any_call(4.375)
+        sleep_mock.assert_any_call(8.5)
+        sleep_mock.assert_any_call(16.5)
+        sleep_mock.assert_any_call(32.25)
+        sleep_mock.assert_any_call(64.125)
+
+
+class Test_not_retryable_predicate(object):
+
+    def test_failure(self):
+        status_codes = (
+            _helpers.TOO_MANY_REQUESTS,
+            http_client.INTERNAL_SERVER_ERROR,
+            http_client.BAD_GATEWAY,
+            http_client.SERVICE_UNAVAILABLE,
+            http_client.GATEWAY_TIMEOUT,
+        )
+        for status_code in status_codes:
+            response = _make_response(status_code)
+            assert not _helpers.not_retryable_predicate(response)
+
+    def test_success(self):
+        status_codes = (http_client.OK, http_client.BAD_REQUEST)
+        for status_code in status_codes:
+            response = _make_response(status_code)
+            assert _helpers.not_retryable_predicate(response)
+
+
 class Test_http_request(object):
 
     @staticmethod
     def _make_transport(*status_codes):
         transport = mock.Mock(spec=[u'request'])
         responses = [
-            mock.Mock(status_code=status_code, spec=[u'status_code'])
-            for status_code in status_codes]
+            _make_response(status_code) for status_code in status_codes]
         transport.request.side_effect = responses
         return transport, responses
 
@@ -141,68 +225,6 @@ class Test_http_request(object):
         transport.request.assert_called_once_with(
             method, url, data=data, headers=headers)
 
-    @mock.patch('time.sleep')
-    @mock.patch('random.randint')
-    def test_success_with_retry(self, randint_mock, sleep_mock):
-        randint_mock.side_effect = [125, 625, 375]
-        transport, responses = self._make_transport(
-            http_client.SERVICE_UNAVAILABLE, _helpers.TOO_MANY_REQUESTS,
-            http_client.SERVICE_UNAVAILABLE, http_client.OK)
-        method = u'POST'
-        url = u'http://test.invalid'
-        data = mock.sentinel.data
-        headers = {u'one': u'fish', u'blue': u'fish'}
-        ret_val = _helpers.http_request(
-            transport, method, url, data=data, headers=headers)
 
-        assert ret_val is responses[3]
-
-        assert transport.request.call_count == 4
-        call = mock.call(method, url, data=data, headers=headers)
-        assert transport.request.mock_calls == [call, call, call, call]
-
-        assert randint_mock.call_count == 3
-        call = mock.call(0, 1000)
-        assert randint_mock.mock_calls == [call, call, call]
-
-        assert sleep_mock.call_count == 3
-        sleep_mock.assert_any_call(1.125)
-        sleep_mock.assert_any_call(2.625)
-        sleep_mock.assert_any_call(4.375)
-
-    @mock.patch('time.sleep')
-    @mock.patch('random.randint')
-    @mock.patch('google.resumable_media._helpers.MAX_CUMULATIVE_RETRY',
-                new=100)
-    def test_retry_exceeds_max_cumulative(self, randint_mock, sleep_mock):
-        randint_mock.side_effect = [875, 0, 375, 500, 500, 250, 125]
-        transport, responses = self._make_transport(
-            _helpers.TOO_MANY_REQUESTS, http_client.INTERNAL_SERVER_ERROR,
-            http_client.BAD_GATEWAY, http_client.SERVICE_UNAVAILABLE,
-            http_client.GATEWAY_TIMEOUT, _helpers.TOO_MANY_REQUESTS,
-            http_client.INTERNAL_SERVER_ERROR, http_client.BAD_GATEWAY)
-        method = u'PUT'
-        url = u'http://test.invalid'
-        data = mock.sentinel.data
-        headers = {u'ok': u'go'}
-        ret_val = _helpers.http_request(
-            transport, method, url, data=data, headers=headers)
-
-        assert ret_val is responses[7]
-
-        assert transport.request.call_count == 8
-        call = mock.call(method, url, data=data, headers=headers)
-        assert transport.request.mock_calls == [call] * 8
-
-        assert randint_mock.call_count == 7
-        call = mock.call(0, 1000)
-        assert randint_mock.mock_calls == [call] * 7
-
-        assert sleep_mock.call_count == 7
-        sleep_mock.assert_any_call(1.875)
-        sleep_mock.assert_any_call(2.0)
-        sleep_mock.assert_any_call(4.375)
-        sleep_mock.assert_any_call(8.5)
-        sleep_mock.assert_any_call(16.5)
-        sleep_mock.assert_any_call(32.25)
-        sleep_mock.assert_any_call(64.125)
+def _make_response(status_code):
+    return mock.Mock(status_code=status_code, spec=[u'status_code'])

--- a/tests/unit/test_upload.py
+++ b/tests/unit/test_upload.py
@@ -412,7 +412,7 @@ class TestResumableUpload(object):
         transport = mock.Mock(spec=[u'request'])
         location = u'http://test.invalid?upload_id=AACODBBBxuw9u3AA',
         response_headers = {u'location': location}
-        post_response = mock.Mock(headers=response_headers, spec=[u'headers'])
+        post_response = _make_response(headers=response_headers)
         transport.request.return_value = post_response
         # Check resumable_url before.
         assert upload._resumable_url is None


### PR DESCRIPTION
Will always retry on 429, 500, 502, 503 and 504. Based on:
https://cloud.google.com/storage/docs/json_api/v1/how-tos/resumable-upload#handling_errors