### PR TITLE
Making sure we pass unicode to `json.loads()` rather than `bytes`.

### DIFF
--- a/google/resumable_media/_upload.py
+++ b/google/resumable_media/_upload.py
@@ -571,7 +571,8 @@ class ResumableUpload(UploadBase):
             response, (http_client.OK, resumable_media.PERMANENT_REDIRECT),
             self._get_status_code, callback=self._make_invalid)
         if status_code == http_client.OK:
-            json_response = json.loads(self._get_body(response))
+            body = self._get_body(response)
+            json_response = json.loads(body.decode('utf-8'))
             self._bytes_uploaded = int(json_response[u'size'])
             # Tombstone the current upload so it cannot be used again.
             self._finished = True

--- a/tests/unit/test__upload.py
+++ b/tests/unit/test__upload.py
@@ -574,6 +574,7 @@ class TestResumableUpload(object):
 
         total_bytes = 158
         response_body = u'{{"size": "{:d}"}}'.format(total_bytes)
+        response_body = response_body.encode('utf-8')
         # Check status before.
         assert upload._bytes_uploaded == 0
         assert not upload._finished


### PR DESCRIPTION
Fixes #12.

After merging a micro release should go out.