### PR TITLE
Using explicit u prefix on unicode string.

### DIFF
--- a/google/resumable_media/_upload.py
+++ b/google/resumable_media/_upload.py
@@ -572,7 +572,7 @@ class ResumableUpload(UploadBase):
             self._get_status_code, callback=self._make_invalid)
         if status_code == http_client.OK:
             body = self._get_body(response)
-            json_response = json.loads(body.decode('utf-8'))
+            json_response = json.loads(body.decode(u'utf-8'))
             self._bytes_uploaded = int(json_response[u'size'])
             # Tombstone the current upload so it cannot be used again.
             self._finished = True

--- a/tests/unit/test__upload.py
+++ b/tests/unit/test__upload.py
@@ -574,7 +574,7 @@ class TestResumableUpload(object):
 
         total_bytes = 158
         response_body = u'{{"size": "{:d}"}}'.format(total_bytes)
-        response_body = response_body.encode('utf-8')
+        response_body = response_body.encode(u'utf-8')
         # Check status before.
         assert upload._bytes_uploaded == 0
         assert not upload._finished


### PR DESCRIPTION
(This is in keeping with all string literals in tests and source code.)