### PR TITLE
Swap the order of _write_to_stream() / _process_response() in `requests` download.

### DIFF
--- a/google/resumable_media/requests/download.py
+++ b/google/resumable_media/requests/download.py
@@ -95,10 +95,11 @@ class Download(_helpers.RequestsMixin, _download.Download):
         result = _helpers.http_request(
             transport, method, url, **request_kwargs)
 
+        self._process_response(result)
+
         if self._stream is not None:
             self._write_to_stream(result)
 
-        self._process_response(result)
         return result
 
 


### PR DESCRIPTION
Since this doesn't actually change the interface, none of the docs for `latest/` or `0.2.2/` need be changed.

Once merged, I propose this commit be tagged as the NEW-AND-IMPROVED `0.2.2` release

/cc @tseaver 