### PR TITLE
Allow empty files to be uploaded.

### DIFF
--- a/google/resumable_media/_upload.py
+++ b/google/resumable_media/_upload.py
@@ -808,7 +808,7 @@ def get_next_chunk(stream, chunk_size, total_bytes):
             # We now **KNOW** the total number of bytes.
             total_bytes = end_byte + 1
     else:
-        if num_bytes_read == 0:
+        if num_bytes_read == 0 and total_bytes != 0:
             raise ValueError(
                 u'Stream is already exhausted. There is no content remaining.')
 
@@ -817,7 +817,7 @@ def get_next_chunk(stream, chunk_size, total_bytes):
             raise ValueError(msg)
 
     content_range = get_content_range(start_byte, end_byte, total_bytes)
-    return start_byte, end_byte, payload, content_range
+    return start_byte, max([end_byte, 0]), payload, content_range
 
 
 def get_content_range(start_byte, end_byte, total_bytes):

--- a/tests/unit/test__upload.py
+++ b/tests/unit/test__upload.py
@@ -860,6 +860,13 @@ class Test_get_next_chunk(object):
         exc_info.match(
             u'Stream is already exhausted. There is no content remaining.')
 
+    def test_exhausted_known_size_zero(self):
+        data = b''
+        stream = io.BytesIO(data)
+        stream.seek(len(data))
+        answer = _upload.get_next_chunk(stream, 1, len(data))
+        assert answer == (0, 0, b'', 'bytes */0')
+
     def test_read_past_known_size(self):
         data = b'more content than we expected'
         stream = io.BytesIO(data)


### PR DESCRIPTION
@dhermes I am not sure this is actually the correct fix for GoogleCloudPlatform/google-cloud-python#3685, but it _seems_ logical and in line with what the original reporter expected.

If this is the wrong answer, I would appreciate guidance on what the correct answer is.

Fixes GoogleCloudPlatform/google-cloud-python#3685