### PR TITLE
Add checksum validation for non-chunked non-composite downloads

### DIFF
--- a/google/resumable_media/__init__.py
+++ b/google/resumable_media/__init__.py
@@ -43,6 +43,7 @@ To install with `pip`_:
 """
 
 
+from google.resumable_media.common import DataCorruption
 from google.resumable_media.common import InvalidResponse
 from google.resumable_media.common import PERMANENT_REDIRECT
 from google.resumable_media.common import RetryStrategy
@@ -51,6 +52,7 @@ from google.resumable_media.common import UPLOAD_CHUNK_SIZE
 
 
 __all__ = [
+    u'DataCorruption',
     u'InvalidResponse',
     u'PERMANENT_REDIRECT',
     u'RetryStrategy',

--- a/google/resumable_media/_download.py
+++ b/google/resumable_media/_download.py
@@ -15,6 +15,7 @@
 """Virtual bases classes for downloading media from Google APIs."""
 
 
+import logging
 import re
 
 from six.moves import http_client
@@ -61,6 +62,7 @@ class DownloadBase(object):
         self._headers = headers
         self._finished = False
         self._retry_strategy = common.RetryStrategy()
+        self._logger = logging.getLogger()
 
     @property
     def finished(self):

--- a/google/resumable_media/common.py
+++ b/google/resumable_media/common.py
@@ -76,6 +76,11 @@ class InvalidResponse(Exception):
         """object: The HTTP response object that caused the failure."""
 
 
+class DataCorruption(Exception):
+    """Error class for corrupt media transfers.
+    """
+
+
 class RetryStrategy(object):
     """Configuration class for retrying failed requests.
 

--- a/google/resumable_media/common.py
+++ b/google/resumable_media/common.py
@@ -78,7 +78,17 @@ class InvalidResponse(Exception):
 
 class DataCorruption(Exception):
     """Error class for corrupt media transfers.
+
+    Args:
+        response (object): The HTTP response which caused the failure.
+        args (tuple): The positional arguments typically passed to an
+            exception class.
     """
+
+    def __init__(self, response, *args):
+        super(DataCorruption, self).__init__(*args)
+        self.response = response
+        """object: The HTTP response object that caused the failure."""
 
 
 class RetryStrategy(object):

--- a/google/resumable_media/requests/download.py
+++ b/google/resumable_media/requests/download.py
@@ -14,8 +14,12 @@
 
 """Support for downloading media from Google APIs."""
 
+import base64
+import hashlib
+import logging
 
 from google.resumable_media import _download
+from google.resumable_media.common import DataCorruption
 from google.resumable_media.requests import _helpers
 
 
@@ -58,12 +62,42 @@ class Download(_helpers.RequestsMixin, _download.Download):
 
         Args:
             response (~requests.Response): The HTTP response object.
+
+        Raises:
+            DataCorruption: If the download's checksum doesn't agree with
+                server-computed checksum.
         """
+        md5_hash = hashlib.md5()
+        # TODO: Add support for validating CRC32C for composite objects. Note
+        # that this is somewhat painful in Python 2 because most OS distros of
+        # Python 2 don't include a compiled crcmod (and executing without a
+        # compiled crcmod is very slow; and installing a compiled crcmod will
+        # make getting google-cloud-python working well more difficult).
+        expected_md5_hash = None
+        if ('X-Goog-Hash' in response.headers
+            and len(response.headers['X-Goog-Hash']) != 0):
+            for checksum in response.headers['X-Goog-Hash'].split(','):
+                name, value = checksum.split('=', 1)
+                if name == 'md5':
+                    expected_md5_hash = value
+        if not expected_md5_hash:
+            logging.getLogger().info(
+                'No MD5 checksum was returned from the service while '
+                'downloading %s (which happens for composite objects), so '
+                'client-side content integrity checking is not being '
+                'performed.' % self.media_url)
         with response:
             body_iter = response.iter_content(
                 chunk_size=_SINGLE_GET_CHUNK_SIZE, decode_unicode=False)
             for chunk in body_iter:
                 self._stream.write(chunk)
+                md5_hash.update(chunk)
+        actual_md5_hash = base64.encodestring(md5_hash.digest()).rstrip('\n')
+        if expected_md5_hash and actual_md5_hash != expected_md5_hash:
+              raise DataCorruption('Checksum mismatch while downloading %s: '
+                                    'expected=%s, actual=%s' %
+                                    (self.media_url, expected_md5_hash,
+                                     actual_md5_hash))
 
     def consume(self, transport):
         """Consume the resource to be downloaded.
@@ -79,6 +113,8 @@ class Download(_helpers.RequestsMixin, _download.Download):
             ~requests.Response: The HTTP response returned by ``transport``.
 
         Raises:
+            DataCorruption: If the download's checksum doesn't agree with
+                server-computed checksum.
             ValueError: If the current :class:`Download` has already
                 finished.
         """

--- a/google/resumable_media/requests/download.py
+++ b/google/resumable_media/requests/download.py
@@ -75,7 +75,7 @@ class Download(_helpers.RequestsMixin, _download.Download):
         # make getting google-cloud-python working well more difficult).
         expected_md5_hash = None
         if ('X-Goog-Hash' in response.headers
-            and len(response.headers['X-Goog-Hash']) != 0):
+            and response.headers['X-Goog-Hash']):
             for checksum in response.headers['X-Goog-Hash'].split(','):
                 name, value = checksum.split('=', 1)
                 if name == 'md5':
@@ -94,7 +94,8 @@ class Download(_helpers.RequestsMixin, _download.Download):
                 md5_hash.update(chunk)
         actual_md5_hash = base64.encodestring(md5_hash.digest()).rstrip('\n')
         if expected_md5_hash and actual_md5_hash != expected_md5_hash:
-              raise DataCorruption('Checksum mismatch while downloading %s: '
+              raise DataCorruption(response,
+                                   'Checksum mismatch while downloading %s: '
                                     'expected=%s, actual=%s' %
                                     (self.media_url, expected_md5_hash,
                                      actual_md5_hash))

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ EXTRAS_REQUIRE = {
 
 setuptools.setup(
     name='google-resumable-media',
-    version='0.2.3',
+    version='0.2.4',
     description='Utilities for Google Media Downloads and Resumable Uploads',
     author='Google Cloud Platform',
     author_email='googleapis-publisher@google.com',

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ EXTRAS_REQUIRE = {
 
 setuptools.setup(
     name='google-resumable-media',
-    version='0.2.4',
+    version='0.2.3',
     description='Utilities for Google Media Downloads and Resumable Uploads',
     author='Google Cloud Platform',
     author_email='googleapis-publisher@google.com',

--- a/tests/unit/requests/test_download.py
+++ b/tests/unit/requests/test_download.py
@@ -170,7 +170,7 @@ def _mock_response(status_code=http_client.OK, chunks=()):
     if chunks:
         response = mock.MagicMock(
             status_code=int(status_code),
-            spec=[u'__enter__', u'__exit__', u'iter_content', u'status_code'],
+            spec=[u'__enter__', u'__exit__', u'iter_content', u'status_code', u'headers'],
         )
         # i.e. context manager returns ``self``.
         response.__enter__.return_value = response


### PR DESCRIPTION
This partially addresses https://github.com/GoogleCloudPlatform/google-resumable-media-python/issues/22

Note current limitations:
  - doesn't handle chunked download case
  - doesn't handle case of downloading composite objects
  - doesn't do anything about upload checksumming

I ran the unit and system tests only against Python 2.7, because my current OS doesn't support Python 3.6.